### PR TITLE
Fix - Parse operationName from the "query" property of a payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ yarn add --dev @shopify/cypress-graphql
 Then in your cypress/support/index files, import the entire package to register these commands.
 
 ```
-import '@shopify/cypress-graphql
+import '@shopify/cypress-graphql';
 ```
 
 Typescript types are automatically included, so no further action is required.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/cypress-graphql",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "description": "Cypress commands for stubbing, intercepting and testing graphql endpoints",
   "main": "dist/index.js",

--- a/src/utils/hasOperationName.ts
+++ b/src/utils/hasOperationName.ts
@@ -1,7 +1,14 @@
 export const hasOperationName = (req: any, operationName: string) => {
   const {body} = req;
-  return (
-    /* eslint-disable-next-line no-prototype-builtins */
-    body.hasOwnProperty('operationName') && body.operationName === operationName
-  );
+  // Standard use case - operationName is included in the req body
+  /* eslint-disable-next-line no-prototype-builtins */
+  if (body.hasOwnProperty('operationName')) {
+    return body.operationName === operationName;
+  }
+  // Edge case - some packages include API calls that don't - so check the query body instead
+  /* eslint-disable-next-line no-prototype-builtins */
+  if (body.hasOwnProperty('query')) {
+    return body.query.includes(operationName);
+  }
+  return false;
 };


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

This fix allows interceptGql to identify an operation based on the `query` in the payload, in case `operationName` is not explicitly used. We currently do this in Linkpop.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes, if applicable.
-->

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
